### PR TITLE
add !important flag to inline style

### DIFF
--- a/lib/hooks/useLayerConfig.ts
+++ b/lib/hooks/useLayerConfig.ts
@@ -11,7 +11,7 @@ export function useLayerConfig<
 
     if (zIndex < 0) throw new Error("Invalid layer key");
 
-    const style = { zIndex };
+    const style = { zIndex: zIndex + " !important" };
     return { style, zIndex };
   };
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",
+  "license": "MIT",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
TLDR: This code does NOT work and breaks the whole library!

React does not support `!important` within inline style objects.

Still, I think this is a pretty cool idea and wanted to create a PR to show the potential of a possible feature like this.